### PR TITLE
Updated "rez" native package to support both Python 2 and 3

### DIFF
--- a/rez/_native/package.py
+++ b/rez/_native/package.py
@@ -66,8 +66,9 @@ def _python_version():
 
     out = exec_python(
         "_python_version",
-        ["import sys",
-         "print sys.version.split()[0]"],
+        ["from __future__ import print_function",
+         "import sys",
+         "print(sys.version.split()[0])"],
          executable="rez-python")
 
     return out


### PR DESCRIPTION
Updated prints to use print function, and forced subprocess to return a str (instead of bytes) in Python 3.